### PR TITLE
Merge python3 support changes

### DIFF
--- a/pelican_mboxreader/mboxreader.py
+++ b/pelican_mboxreader/mboxreader.py
@@ -25,6 +25,7 @@ import mailbox
 import logging
 import os
 import pytz
+import sys
 
 # Other dependency! dateutil.
 try:
@@ -245,7 +246,9 @@ class MboxGenerator(ArticlesGenerator):
             return
 
         all_articles = []
-        for i in xrange(len(mboxPaths)):
+        # To avoid pulling in a dependency, define this convenient lambda.
+        future_range = lambda x: range(x) if not sys.version_info.major <= 2 else xrange(x)
+        for i in future_range(len(mboxPaths)):
             mboxPath = mboxPaths[i]
             mboxCategory = mboxCategories[i]
 

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,8 @@ setup(
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6'
 
         # Other.
         'Topic :: Communications :: Email',


### PR DESCRIPTION
So apparently despite me testing that the module *imported* on Python 3 I never actually tested that it worked! Whoops. This branch fixes this; it now works equally correctly on both Python versions.

I say "equally correctly" because the code to parse emails is still kind of messy and could use some cleanup (and there may be edge cases that aren't covered properly), but it certainly *seems* to work.